### PR TITLE
copy-devices does not properly truncate target file

### DIFF
--- a/copy-devices.diff
+++ b/copy-devices.diff
@@ -146,3 +146,22 @@ diff --git a/sender.c b/sender.c
  		if (append_mode > 0 && st.st_size < F_LENGTH(file)) {
  			rprintf(FWARNING, "skipped diminished file: %s\n",
  				full_fname(fname));
+diff --git a/receiver.c b/receiver.c
+index 9df603f..d5c063c 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -383,8 +383,12 @@ static int receive_data(int f_in, char *fname_r, int fd_r, OFF_T size_r,
+ 	/* inplace: New data could be shorter than old data.
+ 	 * preallocate_files: total_size could have been an overestimate.
+ 	 *     Cut off any extra preallocated zeros from dest file. */
+-	if ((inplace_sizing || preallocated_len > offset) && fd != -1 && !IS_DEVICE(file->mode)) {
+-		if (do_ftruncate(fd, offset) < 0)
++	if ((inplace_sizing || preallocated_len > offset) && fd != -1) {
++		struct stat fd_stat;
++
++		if (fstat(fd, &fd_stat) != 0)
++			rsyserr(FERROR_XFER, errno, "fstat failed on %s", full_fname(fname));
++		else if (!IS_DEVICE(fd_stat.st_mode) && do_ftruncate(fd, offset) < 0)
+ 			rsyserr(FERROR_XFER, errno, "ftruncate failed on %s", full_fname(fname));
+ 	}
+ #endif


### PR DESCRIPTION
When using the --copy-devices with --inplace it does not truncate the target regular file according to the source device size. Here is a simple reproducer:

1. $ Verify /dev/loop0 is not in use.
2. $ losetup -d /dev/loop0;rm -f 512 513
3. $ head -qc512 /dev/urandom >512
4. $ losetup /dev/loop0 512
5. $ head -qc513 /dev/zero >513-to-be-512
6. $ wc -c 513-to-be-512 512 /dev/loop0
       513 513-to-be-512
       512 512
       512 /dev/loop0
       1537 total
7. $ /usr/bin/rsync --inplace --copy-devices /dev/loop0 513-to-be-512
8. $ ls -l 513-to-be-512
    -rw-r--r-- 1 root root 513 Apr 25 20:47 513-to-be-512  <---- should be truncated to 512
9. $ cmp 512 513-to-be-512
       cmp: EOF on 512 after byte 512, in line 2
10. $ losetup -d /dev/loop0

Expected results:
....
8. $ ls -l 513-to-be-512
-rw-r--r-- 1 root root 512 Apr 25 20:47 513-to-be-512

Also, this patch has been around for more than 13 years. Isn't is time to include it in the code? In Fedora, the --copy-devices is being used for 12 years, I think it might have 'simmered' long enough don't you think?

Regards,
Michal