### PR TITLE
Only use this option when it is set by the user

### DIFF
--- a/sparse-block.diff
+++ b/sparse-block.diff
@@ -35,7 +35,7 @@ diff --git a/fileio.c b/fileio.c
  		int r1;
  		if (sparse_files > 0) {
 -			int len1 = MIN(len, SPARSE_WRITE_SIZE);
-+			int len1 = MIN(len, sparse_files_block_size);
++			int len1 = MIN(len, sparse_files_block_size ? sparse_files_block_size : SPARSE_WRITE_SIZE);
  			r1 = write_sparse(f, use_seek, offset, buf, len1);
  			offset += r1;
  		} else {
@@ -46,7 +46,7 @@ diff --git a/options.c b/options.c
  int one_file_system = 0;
  int protocol_version = PROTOCOL_VERSION;
  int sparse_files = 0;
-+long sparse_files_block_size = SPARSE_WRITE_SIZE;
++long sparse_files_block_size = 0;
  int preallocate_files = 0;
  int do_compression = 0;
  int do_compression_level = CLVL_NOT_SPECIFIED;


### PR DESCRIPTION
Hi,
I recently started using this patch because on some systems(and if you know what you are doing) this really brings some interesting speed up of sparse file copying. The only problem with this patch is that it sets the sparse_files_block_size every time, even if the user did not request it. This creates a problem when you are using a patched rsync but communicating with a remote rsync that does not have the patch yet and the error message for parameters misuse is seen every time you run rsync, even when not using the new option:

```
rsync -vvvv [root@devel.xxxx.sk](mailto:root@devel.xxxx.sk):/etc/hosts /tmp/test/
cmd=<NULL> machine=devel.xxxx.sk user=root path=/etc/hosts
cmd[0]=ssh cmd[1]=-l cmd[2]=root cmd[3]=devel.xxxx.sk cmd[4]=rsync cmd[5]=--server cmd[6]=--sender cmd[7]=-vvvve.LsfxC cmd[8]=--sparse-block=1024 cmd[9]=. cmd[10]=/etc/hosts
opening connection using: ssh -l root devel.xxxx.sk rsync --server --sender -vvvve.LsfxC --sparse-block=1024 . /etc/hosts  (11 args)
msg checking charset: UTF-8
rsync: on remote machine: --sparse-block=1024: unknown option
rsync error: syntax or usage error (code 1) at main.c(1568) [server=3.1.2]
rsync: connection unexpectedly closed (0 bytes received so far) [Receiver]
[Receiver] _exit_cleanup(code=12, file=io.c, line=226): entered
rsync error: error in rsync protocol data stream (code 12) at io.c(226) [Receiver=3.1.3]
[Receiver] _exit_cleanup(code=12, file=io.c, line=226): about to call exit(12)
```

When set to 0 at the beginning, it is only sent to the server when specificaly requested by the user.