### PR TITLE
Unprototyped functions are no longer permitted

### DIFF
--- a/detect-renamed.diff
+++ b/detect-renamed.diff
@@ -206,7 +206,7 @@ diff --git a/flist.c b/flist.c
 +		memcpy(the_fattr_list.files, flist->files,
 +		       j * sizeof (struct file_struct *));
 +		qsort(the_fattr_list.files, j,
-+		      sizeof the_fattr_list.files[0], (int (*)())fattr_compare);
++		      sizeof the_fattr_list.files[0], (int (*)(const void *, const void *))fattr_compare);
 +		the_fattr_list.low = 0;
 +		while (j-- > 0) {
 +			struct file_struct *fp = the_fattr_list.files[j];


### PR DESCRIPTION
GCC 15 has landed in Fedora Rawhide and the detect-renamed.diff patch breaks the build when used with the following error:
```
flist.c: In function ‘recv_file_list’:
flist.c:2787:55: warning: cast between incompatible function types from ‘int (*)(struct file_struct **, struct file_struct **)’ to ‘int (*)(void)’ [-Wcast-function-type]
 2787 |                       sizeof the_fattr_list.files[0], (int (*)())fattr_compare);
      |                                                       ^
flist.c:2787:55: error: passing argument 4 of ‘qsort’ from incompatible pointer type [-Wincompatible-pointer-types]
 2787 |                       sizeof the_fattr_list.files[0], (int (*)())fattr_compare);
      |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       int (*)(void)
In file included from rsync.h:330:
/usr/include/stdlib.h:971:34: note: expected ‘__compar_fn_t’ {aka ‘int (*)(const void *, const void *)’} but argument is of type ‘int (*)(void)’
  971 |                    __compar_fn_t __compar) __nonnull ((1, 4));
      |                    ~~~~~~~~~~~~~~^~~~~~~~
/usr/include/stdlib.h:948:15: note: ‘__compar_fn_t’ declared here
  948 | typedef int (*__compar_fn_t) (const void *, const void *);
      |               ^~~~~~~~~~~~~

```
I saw the change I made also somewhere else in rsync - https://github.com/RsyncProject/rsync/blob/master/hlink.c#L120 